### PR TITLE
Accept general kwargs for subprocess run

### DIFF
--- a/src/ptscripts/parser.py
+++ b/src/ptscripts/parser.py
@@ -149,6 +149,7 @@ class Context:
         no_output_timeout_secs: int | None = None,
         capture: bool = False,
         interactive: bool = False,
+        **kwargs,
     ) -> CompletedProcess[str]:
         """
         Run a subprocess.
@@ -160,6 +161,7 @@ class Context:
             no_output_timeout_secs=no_output_timeout_secs,
             capture=capture,
             interactive=interactive,
+            **kwargs,
         )
 
     @contextmanager

--- a/src/ptscripts/process.py
+++ b/src/ptscripts/process.py
@@ -206,10 +206,10 @@ async def _subprocess_run(
     no_output_timeout_secs: int | None = None,
     capture: bool = False,
     interactive: bool = False,
+    **kwargs,
 ):
     stdout = subprocess.PIPE
     stderr = subprocess.PIPE
-    kwargs = {}
     if interactive is False:
         # Run in a separate program group
         if sys.platform.startswith("win"):
@@ -249,6 +249,7 @@ def run(
     no_output_timeout_secs: int | None = None,
     capture: bool = False,
     interactive: bool = False,
+    **kwargs,
 ) -> subprocess.CompletedProcess[str]:
     """
     Run a command.
@@ -265,6 +266,7 @@ def run(
                 no_output_timeout_secs=no_output_timeout_secs,
                 capture=capture,
                 interactive=interactive,
+                **kwargs,
             )
         )
         result = future.result()


### PR DESCRIPTION
Since subprocess run should be doing it's own type checking let it handle kwargs. Rather than enumerating each of it's arguments in Context.run's definition.